### PR TITLE
Slack APIでチャンネルの作成・ユーザーのinvite・チャンネルのアーカイブをするメソッドを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crs-slack-client (0.1.0)
+    crs-slack-client (0.2.0)
       httparty (~> 0.23.1)
       mime-types (~> 3.7)
       multipart-post (~> 2.4)

--- a/lib/crs/slack/client/version.rb
+++ b/lib/crs/slack/client/version.rb
@@ -3,7 +3,7 @@
 module Crs
   module Slack
     class Client
-      VERSION = "0.1.0"
+      VERSION = "0.2.0"
     end
   end
 end

--- a/spec/crs/slack/client_spec.rb
+++ b/spec/crs/slack/client_spec.rb
@@ -89,6 +89,49 @@ RSpec.describe Crs::Slack::Client do
     end
   end
 
+  describe "#conversations_create" do
+    it "新しいチャンネルを作成できる（モック）" do
+      allow(client).to receive(:post).and_return({ "ok" => true, "channel" => { "id" => "C12345" } })
+      res = client.conversations_create(name: "new-channel")
+      expect(res["ok"]).to be true
+      expect(res["channel"]["id"]).to eq("C12345")
+    end
+    it "APIエラー時は例外を投げる" do
+      allow(client).to receive(:post).and_return({ "ok" => false, "error" => "channel_already_exists" })
+      expect do
+        client.conversations_create(name: "existing-channel")
+      end.to raise_error(Crs::Slack::Client::SlackApiError, /Error creating conversation/)
+    end
+  end
+
+  describe '#conversations_invite' do
+    it "チャンネルにユーザーを招待できる（モック）" do
+      allow(client).to receive(:post).and_return({ "ok" => true })
+      res = client.conversations_invite(channel: "C12345", users: ["U1", "U2"])
+      expect(res["ok"]).to be true
+    end
+    it "APIエラー時は例外を投げる" do
+      allow(client).to receive(:post).and_return({ "ok" => false, "error" => "channel_not_found" })
+      expect do
+        client.conversations_invite(channel: "C12345", users: ["U1", "U2"])
+      end.to raise_error(Crs::Slack::Client::SlackApiError, /Error inviting users/)
+    end
+  end
+
+  describe '#conversations_archive' do
+    it "チャンネルをアーカイブできる（モック）" do
+      allow(client).to receive(:post).and_return({ "ok" => true })
+      res = client.conversations_archive(channel: "C12345")
+      expect(res["ok"]).to be true
+    end
+    it "APIエラー時は例外を投げる" do
+      allow(client).to receive(:post).and_return({ "ok" => false, "error" => "channel_not_found" })
+      expect do
+        client.conversations_archive(channel: "C12345")
+      end.to raise_error(Crs::Slack::Client::SlackApiError, /Error archiving conversation/)
+    end
+  end
+
   describe Crs::Slack::Client::ImageUrl do
     it "urlとalt_textを持てる" do
       image = described_class.new(url: "https://example.com/img.png", alt_text: "img")


### PR DESCRIPTION
以下の機能を追加しました ✋ 

1. __チャンネル作成機能__ (`conversations_create`)

   - 新しいSlackチャンネルを作れるようになったよ
   - プライベートかパブリックか選べるパラメータもある

2. __ユーザー招待機能__ (`conversations_invite`)

   - 作ったチャンネルに複数のユーザーをまとめて招待できる
   - ユーザーIDの配列を渡すだけでOK

3. __チャンネルアーカイブ機能__ (`conversations_archive`)

   - もう使わないチャンネルをアーカイブできる
